### PR TITLE
Update moduleraid.js

### DIFF
--- a/moduleraid.js
+++ b/moduleraid.js
@@ -11,14 +11,16 @@ const moduleRaid = function () {
   moduleRaid.mID  = Math.random().toString(36).substring(7);
   moduleRaid.mObj = {};
 
-  const isComet = parseInt(window.Debug?.VERSION?.split(".")?.[1]) >= 3000;
+  moduleRaid.isComet = parseInt(window.Debug?.VERSION?.split(".")?.[1]) >= 3000;
 
   fillModuleArray = function() {
-    if (isComet) {
+    if (moduleRaid.isComet) {
       const moduleKeys = Object.keys(require("__debug").modulesMap);
       for (const moduleKey of moduleKeys) {
         const module = require(moduleKey);
         if (module) {
+          if(!module.default) 
+            module.default = module;
           moduleRaid.mObj[moduleKey] = module;
         } 
       };

--- a/moduleraid.js
+++ b/moduleraid.js
@@ -15,17 +15,27 @@ const moduleRaid = function () {
 
   fillModuleArray = function() {
     if (moduleRaid.isComet) {
-      const moduleKeys = Object.keys(require("__debug").modulesMap);
-      for (const moduleKey of moduleKeys) {
-        const module = require(moduleKey);
-        if (module) {
-          if(!module.default) 
-            module.default = module;
-          moduleRaid.mObj[moduleKey] = module;
-        } 
-      };
+          window.ErrorGuard.skipGuardGlobal(true);
+          
+          const moduleKeys = Object.keys(require("__debug").modulesMap);
+          for (const moduleKey of moduleKeys) {
+              try {
+                  const _module = require(moduleKey);
+                  if (_module) {
+                      let module = { ..._module };
+                      if (!module.hasOwnProperty('default')) {
+                          module.default = module;
+                      }
+                      
+                      moduleRaid.mObj[moduleKey] = module;
+                  }
+              }
+              catch (error) {}
+          };
+
+          window.ErrorGuard.skipGuardGlobal(false);
       return;
-    };
+    }
 
     (window.webpackChunkbuild || window.webpackChunkwhatsapp_web_client).push([
       [moduleRaid.mID], {}, function(e) {


### PR DESCRIPTION
In new web whatsapp version it seems that default property is no longer exists within modules, so we have this worakaround to make same code work for old and new versions:

- Add `isComet` as property to the `moduleRaid` object with a boolean value that tell if current version is comet or not instead of defining it as a constant, which give us the ability to check among this value later in the code if needed.

- Add a property named `default` to the filled module and set the module itself as value of this property, in this way we do not need to make any change for the way we use findModule method inside 'injected.js', 

related pull request link : 
https://github.com/pedroslopez/whatsapp-web.js/pull/2822